### PR TITLE
dodanie do panelu admina możliwości usuwania eventów

### DIFF
--- a/src/features/admin/adminPanel/components/EventsTab/AdminEventsTable/AdminEventsTable.tsx
+++ b/src/features/admin/adminPanel/components/EventsTab/AdminEventsTable/AdminEventsTable.tsx
@@ -1,7 +1,8 @@
-import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons';
 import _ from 'lodash';
 
 import { useApproveEvent } from '@/api/events/approve-event.ts';
+import { useDeleteEvent } from '@/api/events/delete-event.ts';
 import { useEvents } from '@/api/events/get-events';
 import { useRejectEvent } from '@/api/events/reject-event.ts';
 import { Event } from '@/api/events/types';
@@ -39,6 +40,16 @@ export const AdminEventsTable = ({ filter, maxRows }: AdminEventsTableProps) => 
       onSuccess: () => {
         notifications.addNotification({
           message: 'Zgłoszenie odrzucone',
+          type: 'success',
+        });
+      },
+    },
+  });
+  const deleteEvent = useDeleteEvent({
+    mutationConfig: {
+      onSuccess: () => {
+        notifications.addNotification({
+          message: 'Usunięto zdarzenie',
           type: 'success',
         });
       },
@@ -93,6 +104,13 @@ export const AdminEventsTable = ({ filter, maxRows }: AdminEventsTableProps) => 
       icon: faXmark,
       hidden: (item) => item.status === 'rejected',
       onClick: (item) => handleReject(item.eventID),
+      colorVariant: 'warning',
+    },
+    {
+      key: 'delete',
+      title: 'Usuń',
+      icon: faTrash,
+      onClick: (item) => handleDelete(item.eventID),
       colorVariant: 'danger',
     },
   ];
@@ -110,6 +128,13 @@ export const AdminEventsTable = ({ filter, maxRows }: AdminEventsTableProps) => 
       await rejectEvent.mutateAsync(eventId);
     } catch (error) {
       console.error('Błąd podczas odrzucania zgłoszenia:', error);
+    }
+  };
+  const handleDelete = async (userId: number) => {
+    try {
+      await deleteEvent.mutateAsync(userId);
+    } catch (error) {
+      console.error('Błąd podczas usuwania zdarzenia:', error);
     }
   };
 

--- a/src/features/user/userPanel/components/EventsTab/UserEventsTable/UserEventsTable.tsx
+++ b/src/features/user/userPanel/components/EventsTab/UserEventsTable/UserEventsTable.tsx
@@ -90,7 +90,7 @@ export const UserEventsTable = () => {
       title: 'Usuń',
       icon: faTrash,
       onClick: (item) => handleDelete(item.eventID),
-      colorVariant: 'secondary',
+      colorVariant: 'danger',
     },
     {
       key: 'edit',


### PR DESCRIPTION
dodanie do panelu admina możliwości usuwania eventów + 
zmiana koloru odrzucania eventów
NIE JEST PRZETESTOWANE!!!!!
bo na preprod nie działa dodawanie eventów, ale nie powinno się nic wyjebać, ale zanim zmergujemy to trzeba przetestować

![image](https://github.com/dbyszewski/sumy-fe/assets/109089142/392f3e7d-d0ce-4d4d-9a7c-91d74e5b382b)
