### PR TITLE
Add image management functionality to events

### DIFF
--- a/src/api/events/delete-image.ts
+++ b/src/api/events/delete-image.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { DownloadImageParams } from './types';
+
+import { getEventsQueryOptions } from '@/api/events/get-events.ts';
+import { apiClient } from '@/lib/api-client';
+import { MutationConfig } from '@/lib/react-query';
+
+export const deleteEventImage = ({ eventID, fileID }: DownloadImageParams): Promise<never> => {
+  return apiClient.delete(`/events/${eventID}/files/${fileID}`);
+};
+
+interface UseDeleteEventImageOptions {
+  mutationConfig?: MutationConfig<typeof deleteEventImage>;
+}
+
+export const useDeleteEvent = ({ mutationConfig }: UseDeleteEventImageOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig || {};
+
+  return useMutation({
+    onSuccess: (data, ...args) => {
+      queryClient.invalidateQueries({
+        queryKey: getEventsQueryOptions().queryKey,
+      });
+      onSuccess?.(data, ...args);
+    },
+    ...restConfig,
+    mutationFn: deleteEventImage,
+  });
+};

--- a/src/api/events/download-image.ts
+++ b/src/api/events/download-image.ts
@@ -1,0 +1,33 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+
+import { DownloadedImage, DownloadImageParams } from './types';
+
+import { apiClient } from '@/lib/api-client';
+import { QueryConfig } from '@/lib/react-query';
+
+export const downloadEventImage = ({
+  eventID,
+  fileID,
+}: DownloadImageParams): Promise<DownloadedImage> => {
+  return apiClient.get(`/events/${eventID}/files/${fileID}`, {
+    responseType: 'arraybuffer',
+  });
+};
+
+export const downloadEventImageQueryOptions = ({ eventID, fileID }: DownloadImageParams) => {
+  return queryOptions({
+    queryKey: ['events', eventID, 'files', fileID],
+    queryFn: () => downloadEventImage({ eventID, fileID }),
+  });
+};
+
+interface UseEventOptions extends DownloadImageParams {
+  queryConfig?: QueryConfig<typeof downloadEventImageQueryOptions>;
+}
+
+export const useEventImage = ({ eventID, fileID, queryConfig }: UseEventOptions) => {
+  return useQuery({
+    ...downloadEventImageQueryOptions({ eventID, fileID }),
+    ...queryConfig,
+  });
+};

--- a/src/api/events/types.ts
+++ b/src/api/events/types.ts
@@ -10,7 +10,13 @@ export interface Event {
   visibility: boolean;
   longitude: number;
   latitude: number;
+  filesList: string[];
 }
+
+export type DownloadedImage = {
+  data: Blob;
+  contentType: string;
+};
 
 export type Position = {
   lat: number;
@@ -19,6 +25,11 @@ export type Position = {
 
 export interface GetEventParams {
   eventID?: string | number;
+}
+
+export interface DownloadImageParams {
+  eventID: string | number;
+  fileID: string;
 }
 
 export type CreateEventInput = FormData;

--- a/src/components/Elements/Image/Image.tsx
+++ b/src/components/Elements/Image/Image.tsx
@@ -1,0 +1,102 @@
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { useDeleteEvent } from '@/api/events/delete-image.ts';
+import { ImagePreview } from '@/components/Elements/Image/ImagePreview';
+import { useNotifications } from '@/hooks/useNotifications.ts';
+
+interface ImageProps {
+  url: string;
+  fileID: string;
+  eventID: string;
+}
+
+export const ImageComponent = ({ url, fileID, eventID }: ImageProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const notification = useNotifications();
+
+  const deleteEventImage = useDeleteEvent({
+    mutationConfig: {
+      onSuccess: () => {
+        notification.addNotification({
+          message: 'Usunięto zdjęcie',
+          type: 'success',
+        });
+      },
+    },
+  });
+
+  const toggleModal = useCallback(() => {
+    setIsModalOpen(!isModalOpen);
+  }, [isModalOpen]);
+
+  const handleDelete = async () => {
+    try {
+      await deleteEventImage.mutateAsync({ eventID, fileID });
+    } catch (error) {
+      console.error('Błąd podczas usuwania użytkownika:', error);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      <RelativeContainer>
+        <ImageOverlay
+          initial={{ opacity: 0, y: '-20rem' }}
+          animate={{ opacity: 'inherit', y: 0 }}
+          exit={{ opacity: 0, y: '20rem' }}
+          whileHover={{ scale: 1.2 }}
+          transition={{ duration: 0.5, type: 'spring' }}
+          onClick={toggleModal}>
+          <StyledImage src={url} />
+        </ImageOverlay>
+        <DeleteButton onClick={handleDelete}>
+          <FontAwesomeIcon icon={faTrash} />
+        </DeleteButton>
+      </RelativeContainer>
+      <ImagePreview src={url} open={isModalOpen} onClose={toggleModal} />
+    </AnimatePresence>
+  );
+};
+
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+
+const ImageOverlay = styled(motion.button)`
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const DeleteButton = styled(motion.button)`
+  border: none;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  color: ${({ theme }) => theme.colors.text.light};
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 5rem;
+  background-color: ${({ theme }) => theme.colors.buttons.danger};
+  padding: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+`;
+
+const RelativeContainer = styled.div`
+  position: relative;
+`;

--- a/src/components/Elements/Image/ImageContainer.tsx
+++ b/src/components/Elements/Image/ImageContainer.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import styled from 'styled-components';
+
+import { useEventImage } from '@/api/events/download-image.ts';
+import { ImageComponent } from '@/components/Elements/Image/Image.tsx';
+import { LoadingSpinner } from '@/components/Elements/LoadingSpinner';
+
+interface ImageProps {
+  fileID: string;
+  eventID: string;
+}
+
+export const ImageContainer = ({ eventID, fileID }: ImageProps) => {
+  const eventImageQuery = useEventImage({ eventID, fileID });
+
+  const renderContent = useMemo(() => {
+    if (eventImageQuery.isLoading) {
+      return <LoadingSpinner />;
+    }
+    if (eventImageQuery.isError) {
+      return <div>Wystąpił błąd podczas ładowania zdjęcia</div>;
+    }
+    if (!eventImageQuery.data) return <div>Brak zdjęcia</div>;
+
+    const blob = new Blob([eventImageQuery.data.data], { type: eventImageQuery.data.contentType });
+    const url = URL.createObjectURL(blob);
+    return <ImageComponent url={url} eventID={eventID} fileID={fileID} />;
+  }, [eventImageQuery]);
+
+  return <Container>{renderContent}</Container>;
+};
+
+const Container = styled.div`
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  height: fit-content;
+  flex: 1;
+  min-width: 20rem;
+  background-color: ${({ theme }) => theme.colors.elements.light};
+`;

--- a/src/components/Elements/Image/ImagePreview.tsx
+++ b/src/components/Elements/Image/ImagePreview.tsx
@@ -1,0 +1,102 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AnimatePresence, motion } from 'framer-motion';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+
+interface ImagePreviewProps {
+  src: string;
+  onClose: () => void;
+  open: boolean;
+}
+
+export const ImagePreview = ({ src, onClose, open }: ImagePreviewProps) => {
+  const modalRoot = document.body;
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <Modal
+          initial={{
+            opacity: 0,
+          }}
+          animate={{
+            opacity: 1,
+          }}
+          exit={{
+            opacity: 0,
+          }}
+          transition={{ duration: 0.3 }}>
+          <StyledImage
+            src={src}
+            alt=""
+            initial={{
+              scale: 0,
+              x: '20rem',
+            }}
+            animate={{
+              scale: 1,
+              x: 0,
+            }}
+            exit={{
+              scale: 0,
+            }}
+            transition={{ duration: 0.4, type: 'spring' }}
+          />
+          <CloseButton
+            onClick={onClose}
+            initial={{
+              scale: 0,
+              x: '20rem',
+            }}
+            animate={{
+              scale: 1,
+              x: 0,
+            }}
+            exit={{
+              scale: 0,
+            }}
+            transition={{ duration: 0.4, type: 'spring' }}>
+            <FontAwesomeIcon icon={faXmark} />
+          </CloseButton>
+        </Modal>
+      )}
+    </AnimatePresence>,
+    modalRoot
+  );
+};
+
+const Modal = styled(motion.div)`
+  position: fixed;
+  top: -20rem;
+  left: -20rem;
+  padding: 20rem;
+  width: calc(100% + 40rem);
+  height: calc(100% + 40rem);
+  z-index: 100;
+  background-color: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+`;
+
+const CloseButton = styled(motion.button)`
+  border: none;
+  position: absolute;
+  top: 21rem;
+  right: 21rem;
+  color: ${({ theme }) => theme.colors.text.themeDark};
+  font-size: 1.75rem;
+  cursor: pointer;
+  border-radius: 5rem;
+  background-color: ${({ theme }) => theme.colors.elements.light};
+  padding: 0.5rem;
+  width: 3rem;
+  height: 3rem;
+`;
+
+const StyledImage = styled(motion.img)`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 5rem;
+`;

--- a/src/components/Elements/Image/index.tsx
+++ b/src/components/Elements/Image/index.tsx
@@ -1,0 +1,1 @@
+export * from './ImageContainer.tsx';

--- a/src/features/admin/adminPanel/components/EventsTab/EventDetailsCard.tsx
+++ b/src/features/admin/adminPanel/components/EventsTab/EventDetailsCard.tsx
@@ -8,6 +8,7 @@ import { SingleEventMap } from './SingleEventMap';
 
 import { useEvent } from '@/api/events/get-event.ts';
 import { Title } from '@/components/Elements/Headers/Title';
+import { ImageContainer } from '@/components/Elements/Image';
 import { LoadingSpinner } from '@/components/Elements/LoadingSpinner';
 import { StatusIconWithTooltip } from '@/features/admin/adminPanel/components/StatusIconWithTooltip.tsx';
 import { formatDateTime } from '@/utils/dateHelper.ts';
@@ -74,6 +75,12 @@ export const EventDetailsCard = () => {
         <MapContainer>
           <SingleEventMap position={{ lat: event.latitude, lng: event.longitude }} />
         </MapContainer>
+        <ImagesContainer>
+          {eventId &&
+            event.filesList.map((fileId) => (
+              <ImageContainer key={fileId} fileID={fileId} eventID={eventId} />
+            ))}
+        </ImagesContainer>
       </RowsContainer>
     </Content>
   );
@@ -109,6 +116,7 @@ const RowsContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: 1rem;
+  gap: 1rem;
 `;
 
 const Row = styled.div`
@@ -135,8 +143,13 @@ const ColumnRight = styled.div`
 const MapContainer = styled.div`
   height: 20rem;
   background: #e5e5e5;
-  margin-top: 3rem;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   border-radius: 1rem;
   overflow: hidden;
+`;
+
+const ImagesContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
 `;

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -18,6 +18,13 @@ apiClient.interceptors.request.use((config) => {
 
 apiClient.interceptors.response.use(
   (response) => {
+    if (response.headers['content-type'] === 'application/octet-stream') {
+      return {
+        data: response.data,
+        contentType: response.headers['content-type'],
+      };
+    }
+
     if (response.data?.result) return response.data.result;
 
     return response.data;
@@ -40,9 +47,6 @@ apiClient.interceptors.response.use(
       } else {
         toast.error('Nieokreślony błąd walidacji');
       }
-    }
-    if (error.response.status === 404) {
-      toast.error('Nie znaleziono');
     }
     if (error.response.status === 403) {
       toast.error('Nie masz prawa');


### PR DESCRIPTION
This commit introduces the ability to add, preview, and delete images related to events. The main changes are the creation of `ImageContainer`, `ImagePreview`, and `ImageComponent` tsx files which handle the display and manipulation of image data. Functions to download and delete images from events have also been added to the events API. Lastly, the event details card has been updated to display image content.