### PR TITLE
Update validation for eventDate in ReportDataForm

### DIFF
--- a/src/features/report/components/ReportDataForm.tsx
+++ b/src/features/report/components/ReportDataForm.tsx
@@ -24,7 +24,13 @@ const schema = yup
         otherwise: (schema) => schema.notRequired(),
       }),
     description: yup.string().required('Opis jest wymagany'),
-    eventDate: yup.string().required('Data zdarzenia jest wymagana'),
+    eventDate: yup
+      .date()
+      .required('Data zdarzenia jest wymagana')
+      .max(
+        new Date(),
+        ({ max }) => `Data zdarzenia nie może być późniejsza niż ${max.toLocaleString()}`
+      ),
   })
   .required();
 
@@ -89,7 +95,6 @@ export const ReportDataForm = ({ initialValues }: ReportDataFormProps) => {
           <DateTime
             label="Data zdarzenia"
             id="eventDate"
-            max={new Date().toISOString().split('.')[0]}
             {...field}
             error={errors.eventDate?.message}
           />


### PR DESCRIPTION
Changed the type of validation for eventDate from string to date in ReportDataForm component. Also added a restriction that the eventDate cannot be a future date. Removed redundant maximum date limit from the DateTime field.